### PR TITLE
Dataset page 

### DIFF
--- a/src/Components/DatasetDetails.js
+++ b/src/Components/DatasetDetails.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactHtmlParser from 'react-html-parser';
-import data from '../data/datasets.json';
 import './DatasetDetails.scss';
 import UrlBuilder from './UrlBuilder';
 import PlotBuilder from './PlotBuilder';
 import ModelScoresTable from './ModelScoresTable';
+import data from '../data/datasets.json';
 
 class DatasetDetails extends React.Component {
   constructor(props) {
@@ -43,6 +43,9 @@ class DatasetDetails extends React.Component {
             </tr>
           </tbody>
         </table>
+        <div className="add-model-link">
+          <a href={UrlBuilder.submitPageUrl}>Add model</a>
+        </div>
         <PlotBuilder dataset={this.dataset} />
         <ModelScoresTable models={this.dataset.models} metrics={this.dataset.metrics} />
       </>

--- a/src/Components/DatasetDetails.scss
+++ b/src/Components/DatasetDetails.scss
@@ -41,7 +41,7 @@ text {
 }
 
 .title {
-  font-size: 1.6em;
+  font-size: 1.2em;
   fill: #635F5D;
 }
 

--- a/src/Components/DatasetDetails.scss
+++ b/src/Components/DatasetDetails.scss
@@ -49,3 +49,11 @@ text {
     width:100%;
     height: 300px;
 }
+
+.add-model-link{
+    text-align: right;
+    border-top: 1px solid #ccc;
+    padding-right: 10px;
+    margin-top: 10px;
+    padding-top: 10px;
+}

--- a/src/Components/DatasetDetails.scss
+++ b/src/Components/DatasetDetails.scss
@@ -57,3 +57,7 @@ text {
     margin-top: 10px;
     padding-top: 10px;
 }
+
+#select-metric-group{
+    width: 25%;
+}

--- a/src/Components/PlotBuilder.js
+++ b/src/Components/PlotBuilder.js
@@ -57,7 +57,7 @@ class PlotBuilder extends Component {
             height={this.state.height}
           />
         </div>
-        <div className="input-group">
+        <div id="select-metric-group" className="input-group input-group-sm">
           <div className="input-group-prepend">
             <label className="input-group-text" htmlFor="metrics">
               View scores for:

--- a/src/Components/ScatterPlot.js
+++ b/src/Components/ScatterPlot.js
@@ -103,7 +103,7 @@ class ScatterPlot extends Component {
     g.append('text')
       .attr('class', 'title')
       .attr('x', innerWidth / 2)
-      .attr('y', -10)
+      .attr('y', -30)
       .attr('text-anchor', 'middle')
       .text(title);
   }

--- a/src/Components/ScatterPlot.js
+++ b/src/Components/ScatterPlot.js
@@ -50,7 +50,7 @@ class ScatterPlot extends Component {
     yAxisG
       .append('text')
       .attr('class', 'axis-label')
-      .attr('y', -93)
+      .attr('y', -55)
       .attr('x', -innerHeight / 2)
       .attr('fill', 'black')
       .attr('transform', `rotate(-90)`)
@@ -64,7 +64,7 @@ class ScatterPlot extends Component {
     xAxisG
       .append('text')
       .attr('class', 'axis-label')
-      .attr('y', 75)
+      .attr('y', 50)
       .attr('x', innerWidth / 2)
       .attr('fill', 'black')
       .text(xAxisLabel);


### PR DESCRIPTION
1. Could we add to the right of Source and License a button (right aligned), with green like the one on the header, where it says "Add model" and links to the add model page like in the header? The space to the right of the Source/License is perfect for such a button.
2. For the graph, make "Task leaderboard" a bit smaller and place it a bit higher? It feels crowded in the graph now.
3. The graph has too many horizontal lines imho, the numbers almost touch one another, I think 10 vertical ticks with numbers on them should be more than enough. The tooltip does the rest.
4. In the graph the labels Score and Submission date are too spaced-out, could we bring them closed to the graph ? And thus make the graph stretch more on the x axis?
5. Make the view scores dropdown smaller, like a 3-5-10em wide and right align it? Also make it smaller (both font and vertical height).

☮️ 
