### PR TITLE
UPDATE-INDEX workflow fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy pandas xlrd
+        pip install -r requirements.txt
     - uses: actions/checkout@master
       with:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy==1.19.1
+pandas==1.1.1
+python-dateutil==2.8.1
+pytz==2020.1
+regex==2020.7.14
+six==1.15.0
+xlrd==1.2.0


### PR DESCRIPTION
The workflow fails with the following error:
```sh
2021-01-19 17:45:59,291 : INFO : Start extracting data from LEADERBOARD.xlsx...
Traceback (most recent call last):
  File "extract_data.py", line 600, in <module>
    run(args)
  File "extract_data.py", line 535, in run
    leaderboard = read_excel(args.excel_file, args.leaderboard_sheet)
  File "extract_data.py", line 48, in read_excel
    df = pd.read_excel(file_name, sheet_name=sheet_name)
  File "/opt/hostedtoolcache/Python/3.8.7/x64/lib/python3.8/site-packages/pandas/util/_decorators.py", line 299, in wrapper
    return func(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.7/x64/lib/python3.8/site-packages/pandas/io/excel/_base.py", line 336, in read_excel
    io = ExcelFile(io, storage_options=storage_options, engine=engine)
  File "/opt/hostedtoolcache/Python/3.8.7/x64/lib/python3.8/site-packages/pandas/io/excel/_base.py", line 1085, in __init__
    raise ValueError(
ValueError: Your version of xlrd is 2.0.1. In xlrd >= 2.0, only the xls format is supported. Install openpyxl instead.
Error: Process completed with exit code 1.
```