### PR TITLE
Fixed bug on expanding dates

### DIFF
--- a/src/data/extract_data.py
+++ b/src/data/extract_data.py
@@ -134,13 +134,23 @@ class ChartDataBuilder(object):
         """
         current_month = datetime.date.today().replace(day=1)
         min_date = min(dates) if len(dates) > 0 else current_month
-        year = min_date.year - 1 if min_date.month == 1 else min_date.year
-        min_date = min_date.replace(year=year, month=min_date.month - 1)
+        if min_date.month == 1:
+            year = min_date.year - 1
+            month = 12
+        else:
+            year = min_date.year
+            month = min_date.month - 1
+        min_date = min_date.replace(year=year, month=month)
         dates.add(min_date)
 
         max_date = max(dates) if len(dates) > 0 else current_month
-        year = max_date.year + 1 if max_date.month == 12 else max_date.year
-        dates.add(max_date.replace(year=year, month=max_date.month + 1))
+        if max_date.month == 12:
+            year = max_date.year + 1
+            month = 1
+        else:
+            year = max_date.year
+            month = max_date.month + 1
+        dates.add(max_date.replace(year=year, month=month))
 
     def _accumulate_dates(self, accumulator, model):
         """Adds the submission date of the model to the accumulator


### PR DESCRIPTION
The `import_data.py` script fails when expanding the dates of a task submissions, if the minimum date of a task is on first month (any year), or when the maximum date of a task is on the last month (any year).

The changes in this PR make sure that:
- if the minimum date of a task is on January (any year) then the minimum date is set to December from previous year, and
- if the maximum date of a task is on December (any year) then the maximum date is set to January next year.

This PR fixes #33.