### PR TITLE
Removed description section from long description files

### DIFF
--- a/datasets/LaRoSeDa.md
+++ b/datasets/LaRoSeDa.md
@@ -1,10 +1,6 @@
-### Description:
-
-LaRoSeDa, the Large Romanian Sentiment Data Set, contains 15000 product reviews written in Romanian. There are 7500 positive (star ratings 4 and 5) and 7500 negative (star ratings 1 and 2) reviews. The data set is divided into two subsets: training (12000 samples) and test (3000 samples). 
-
 ### Input, Output and Metrics:
 
-The task is to classify each review according to its star rating. Given the training set, the target is to maximize the macro-averaged F1 score on the test set. 
+The task is to classify each review according to its star rating. Given the training set, the target is to maximize the macro-averaged F1 score on the test set.
 
 The reported metric is the **Macro-averaged F1 score**.
 

--- a/datasets/MOROCO.md
+++ b/datasets/MOROCO.md
@@ -1,10 +1,6 @@
-### Description:
-
-MOROCO, the Moldavian and Romanian Dialectal Corpus, contains Moldavian and Romanian samples of text collected from the news domain. The samples belong to one of the following six topics: culture, finance, politics, science, sports, tech. The data set is divided into three subsets: training (21719 samples), validation (5921 samples), test (5924 samples).
-
 ### Input, Output and Metrics:
 
-The task is to classify each news article into one of the six classes. Given the training and validation sets, the target is to maximize the macro-averaged F1 score on the test set. 
+The task is to classify each news article into one of the six classes. Given the training and validation sets, the target is to maximize the macro-averaged F1 score on the test set.
 
 The reported metric is the **Macro-averaged F1 score**.
 
@@ -18,7 +14,7 @@ The following script loads the data samples into memory:
 
 [https://github.com/butnaruandrei/MOROCO/blob/master/loadDataSet.py](https://github.com/butnaruandrei/MOROCO/blob/master/loadDataSet.py)
 
-With minor changes, the following script can be used for the evaluation: 
+With minor changes, the following script can be used for the evaluation:
 
 [https://github.com/butnaruandrei/MOROCO/blob/master/MOROCO/Var-Dial-MRC-2019-eval/eval.py](https://github.com/butnaruandrei/MOROCO/blob/master/MOROCO/Var-Dial-MRC-2019-eval/eval.py)
 

--- a/datasets/RO-STS.md
+++ b/datasets/RO-STS.md
@@ -1,7 +1,3 @@
-### Description:
-
-RO-STS, the Romanian Semantic Textual Similarity Dataset, contains 8628 pairs of sentences with their similarity score. This Romanian dataset is a high-quality translation of the English [STS](https://ixa2.si.ehu.eus/stswiki/index.php/STSbenchmark) dataset. The data set is divided into three subsets: training (5749 sentence pairs), validation (1500 sentence pairs), test (1379 sentence pairs).
-
 ### Input, Output and Metrics:
 
 The task is to measure how similar two given sentences are.

--- a/datasets/RONEC-v1.0.md
+++ b/datasets/RONEC-v1.0.md
@@ -1,7 +1,3 @@
-### Description:
-
-RONEC, the ROmanian Named Entity Corpus, holds in its 1.0 version a number of 5127 sentences, annotated with 16 classes, having in total 26376 annotated entities.
-
 ### Input, Output and Metrics:
 
 Given the train & validation sets, the target is to maximize the F1 score on the test set.
@@ -29,9 +25,9 @@ If you use this dataset in a published work, please cite the following:
 or in .bibtex format:
 
 
->     @article{dumitrescu2019introducing,   
->       title={Introducing RONEC--the Romanian Named Entity Corpus},   
->       author={Dumitrescu, Stefan Daniel and Avram, Andrei-Marius},   
->       journal={arXiv preprint arXiv:1909.01247},   
->       year={2019}   
+>     @article{dumitrescu2019introducing,
+>       title={Introducing RONEC--the Romanian Named Entity Corpus},
+>       author={Dumitrescu, Stefan Daniel and Avram, Andrei-Marius},
+>       journal={arXiv preprint arXiv:1909.01247},
+>       year={2019}
 >     }

--- a/datasets/UniversalDependencies-RO-RRT-v2.5.md
+++ b/datasets/UniversalDependencies-RO-RRT-v2.5.md
@@ -1,17 +1,3 @@
-### Description:
-
-[Universal Dependencies](https://universaldependencies.org/) (UD) is a framework for consistent annotation of grammar (parts of speech, morphological features, and syntactic dependencies) across different human languages. 
-
-The Romanian RRT Treebank is the standard treebank for Romanian. 
-
-This page is common for the following tasks:
-- UD Romanian RRT Treebank 2.5 - **Tokenization**
-- UD Romanian RRT Treebank 2.5 - **Sentence Segmentation**
-- UD Romanian RRT Treebank 2.5 - **Lemmatization**
-- UD Romanian RRT Treebank 2.5 - **POS Tagging**
-- UD Romanian RRT Treebank 2.5 - **Dependency parsing**
-
-
 ### Input, Output and Metrics:
 
 There are train, dev and test files, in raw format (text) and in the CoNLL-U.
@@ -20,11 +6,13 @@ Full details on the CoNLL-U format are found [here](https://universaldependencie
 To perform evaluation, please use the official script available [here](http://universaldependencies.org/conll18/evaluation.html). It offers both prediction_file/gold_file and in-memory functions, evaluating all target metrics in one go.
 
 Per task metrics (as given by the evaluation script above):
+
 - **Tokenization**: **Tokens** F1 score
 - **Sentence Segmentation**: **Sentences** F1 score
 - **Lemmatization**: **Lemma** F1 score
 - **POS Tagging**: **UPOS**, **XPOS** and **AllTags**  F1 scores
 - **Dependency parsing**: **UAS** and **LAS** F1 scores
+
 
 ### Download from:
 

--- a/datasets/Wiki-ro.md
+++ b/datasets/Wiki-ro.md
@@ -1,7 +1,3 @@
-### Description:
-
-RONEC, the ROmanian Named Entity Corpus, holds in its 1.0 version a number of 5127 sentences, annotated with 16 classes, having in total 26376 annotated entities.
-
 ### Input, Output and Metrics:
 
 Given the train & validation sets, the target is to maximize the F1 score on the test set.
@@ -29,9 +25,9 @@ If you use this dataset in a published work, please cite the following:
 or in .bibtex format:
 
 
->     @article{dumitrescu2019introducing,   
->       title={Introducing RONEC--the Romanian Named Entity Corpus},   
->       author={Dumitrescu, Stefan Daniel and Avram, Andrei-Marius},   
->       journal={arXiv preprint arXiv:1909.01247},   
->       year={2019}   
+>     @article{dumitrescu2019introducing,
+>       title={Introducing RONEC--the Romanian Named Entity Corpus},
+>       author={Dumitrescu, Stefan Daniel and Avram, Andrei-Marius},
+>       journal={arXiv preprint arXiv:1909.01247},
+>       year={2019}
 >     }

--- a/datasets/XQuAD-ro.md
+++ b/datasets/XQuAD-ro.md
@@ -1,7 +1,3 @@
-### Description:
-
-RONEC, the ROmanian Named Entity Corpus, holds in its 1.0 version a number of 5127 sentences, annotated with 16 classes, having in total 26376 annotated entities.
-
 ### Input, Output and Metrics:
 
 Given the train & validation sets, the target is to maximize the F1 score on the test set.
@@ -29,9 +25,9 @@ If you use this dataset in a published work, please cite the following:
 or in .bibtex format:
 
 
->     @article{dumitrescu2019introducing,   
->       title={Introducing RONEC--the Romanian Named Entity Corpus},   
->       author={Dumitrescu, Stefan Daniel and Avram, Andrei-Marius},   
->       journal={arXiv preprint arXiv:1909.01247},   
->       year={2019}   
+>     @article{dumitrescu2019introducing,
+>       title={Introducing RONEC--the Romanian Named Entity Corpus},
+>       author={Dumitrescu, Stefan Daniel and Avram, Andrei-Marius},
+>       journal={arXiv preprint arXiv:1909.01247},
+>       year={2019}
 >     }


### PR DESCRIPTION
To avoid showing duplicate description for each dataset, the (redundant) description section was removed from long description file of each dataset.

This pull-request closes #54.