### PR TITLE
Improvements of the datasets page

### DIFF
--- a/datasets/RO-STS-parallel-site.md
+++ b/datasets/RO-STS-parallel-site.md
@@ -1,3 +1,3 @@
-The **Romanian Semantic Textual Similarity Parallel Dataset** (RO-STS-Parallel)[https://github.com/dumitrescustefan/RO-STS] is a high quality translation of the English [STS](https://ixa2.si.ehu.eus/stswiki/index.php/STSbenchmark) dataset that serves as a Romanian English parallel dataset.
+The **Romanian Semantic Textual Similarity Parallel Dataset** [RO-STS-Parallel](https://github.com/dumitrescustefan/RO-STS) is a high quality translation of the English [STS](https://ixa2.si.ehu.eus/stswiki/index.php/STSbenchmark) dataset that serves as a Romanian English parallel dataset.
 
 The dataset consists of 17256 sentence pairs in Romanian and English belonging to categories such as news headlines, image captions and user forums. On this dataset the task of **machine translation** can be performed.

--- a/src/Components/Datasets.js
+++ b/src/Components/Datasets.js
@@ -23,9 +23,6 @@ class Datasets extends React.Component {
         <div className="row dataset-info">
           <ul>
             <li>
-              <span>license:</span> {dataset.license}
-            </li>
-            <li>
               <span>submissions:</span> {dataset.models.length}
             </li>
             <li>

--- a/src/Components/Datasets.js
+++ b/src/Components/Datasets.js
@@ -23,6 +23,9 @@ class Datasets extends React.Component {
         <div className="row dataset-info">
           <ul>
             <li>
+              <span>task:</span> <a href={this.urlBuilder.buildTaskUrl({ id: dataset.task_id })}>{dataset.task}</a>
+            </li>
+            <li>
               <span>submissions:</span> {dataset.models.length}
             </li>
             <li>

--- a/src/Components/Datasets.js
+++ b/src/Components/Datasets.js
@@ -19,7 +19,7 @@ class Datasets extends React.Component {
             <a href={this.urlBuilder.buildDatasetUrl(dataset)}>{dataset.dataset_name}</a>
           </h2>
         </div>
-        <div className="row dataset-description">{ReactHtmlParser(dataset.dataset_description)}</div>
+        <div className="row dataset-description">{ReactHtmlParser(dataset.short_description)}</div>
         <div className="row dataset-info">
           <ul>
             <li>

--- a/src/Components/Datasets.js
+++ b/src/Components/Datasets.js
@@ -23,6 +23,9 @@ class Datasets extends React.Component {
         <div className="row dataset-info">
           <ul>
             <li>
+              <span>area:</span> {dataset.area}
+            </li>
+            <li>
               <span>task:</span> <a href={this.urlBuilder.buildTaskUrl({ id: dataset.task_id })}>{dataset.task}</a>
             </li>
             <li>

--- a/src/Components/Datasets.scss
+++ b/src/Components/Datasets.scss
@@ -14,6 +14,7 @@
 
 .dataset-row{
     margin-top: 20px;
+    margin-left: 10px;
     .dataset-description{
 	margin-top: 0em;
 	margin-bottom: 0px;
@@ -23,6 +24,7 @@
 	    list-style: none;
 	    padding: 0;
 	    margin-bottom: 10px;
+	    margin-left: 15px;
 	    li{
 		display: inline;
 

--- a/src/data/extract_data.py
+++ b/src/data/extract_data.py
@@ -423,6 +423,7 @@ class DatasetsDetailsBuilder(object):
         dataset_id = build_id_string(row[DatasetColumns.DatasetName])
         logging.info("Building dataset {}.".format(dataset_id))
 
+        task_id = build_id_string(row[DatasetColumns.Task])
         description = self._get_dataset_description(
             row, DatasetColumns.ShortDescription)
         dataset_info = self._get_dataset_description(
@@ -435,6 +436,7 @@ class DatasetsDetailsBuilder(object):
             DatasetColumns.License] else "Not specified"
         return {
             "task": row[DatasetColumns.Task],
+            "task_id": task_id,
             "id": dataset_id,
             "dataset_name": row[DatasetColumns.DatasetName],
             "dataset_description": description,

--- a/src/data/extract_data.py
+++ b/src/data/extract_data.py
@@ -455,11 +455,13 @@ class DatasetsDetailsBuilder(object):
 
         license = row[DatasetColumns.License] if row[
             DatasetColumns.License] else "Not specified"
+        short_description = self._get_dataset_short_description(description)
         return {
             "task": row[DatasetColumns.Task],
             "id": dataset_id,
             "dataset_name": row[DatasetColumns.DatasetName],
             "dataset_description": description,
+            "short_description": short_description,
             "dataset_info": dataset_info,
             "dataset_link": row[DatasetColumns.DatasetLink],
             "preferred_metric": row[DatasetColumns.PreferredMetric],
@@ -467,6 +469,29 @@ class DatasetsDetailsBuilder(object):
             "license_url": row[DatasetColumns.LicenseURL],
             "models": []
         }
+
+    def _get_dataset_short_description(self, html_description):
+        """Extracts first paragraph of the description.
+
+        Parameters
+        ----------
+        html_description: str
+            The string containing dataset description in HTML format.
+
+        Returns
+        -------
+        short_description: str
+            The first paragraph of the HTML description.
+        """
+        index = html_description.find('</p>')
+        if index <= 0:
+            logging.warning(
+                "Could not build short description from html string: {}.".
+                format(html_description))
+            return html_description
+        
+        return html_description[:index + len('</p>')]
+        
 
     def _get_dataset_description(self, row, column):
         """Loads the descripton for the dataset from the description file.


### PR DESCRIPTION
- Moved to the right the blocks containing dataset info
- The page now displays the first paragraph from the dataset description
- In dataset properties:
  - Removed license
  - Added task area
  - Added task with link to task page.

This pull request closes #66.